### PR TITLE
Changed config path for SH fields to avoid conflict with General tab

### DIFF
--- a/app/code/Shiphawk/Order/Model/Cron/ProcessOrderForLast14Days.php
+++ b/app/code/Shiphawk/Order/Model/Cron/ProcessOrderForLast14Days.php
@@ -30,7 +30,7 @@ class ProcessOrderForLast14Days
 
     public function execute()
     {
-        $active = $this->scopeConfig->getValue('general/options/shiphawk_active',
+        $active = $this->scopeConfig->getValue('shiphawk_order/options/shiphawk_active',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         if (!$active) {

--- a/app/code/Shiphawk/Order/Observer/ChangeStatus.php
+++ b/app/code/Shiphawk/Order/Observer/ChangeStatus.php
@@ -53,9 +53,9 @@ class ChangeStatus implements ObserverInterface
 
     protected function _push($jsonOrderRequest, $order) {
 
-        $api_key = $this->scopeConfig->getValue('general/options/shiphawk_api_key',
+        $api_key = $this->scopeConfig->getValue('shiphawk_order/options/shiphawk_api_key',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
-        $gateway_url = $this->scopeConfig->getValue('general/options/shiphawk_gateway_url',
+        $gateway_url = $this->scopeConfig->getValue('shiphawk_order/options/shiphawk_gateway_url',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         $params = http_build_query(['api_key' => $api_key]);

--- a/app/code/Shiphawk/Order/Observer/CheckConfiguration.php
+++ b/app/code/Shiphawk/Order/Observer/CheckConfiguration.php
@@ -47,7 +47,7 @@ class CheckConfiguration implements ObserverInterface
         if (property_exists($response, 'error')) {
             $this->messageManager->addError('Unable to authenticate ShipHawk API key.');
             $this->resourceConfig->saveConfig(
-                'general/options/shiphawk_active',
+                'shiphawk_order/options/shiphawk_active',
                 '0',
                 \Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
                 \Magento\Store\Model\Store::DEFAULT_STORE_ID
@@ -60,9 +60,9 @@ class CheckConfiguration implements ObserverInterface
     }
 
     protected function _get() {
-        $api_key = $this->scopeConfig->getValue('general/options/shiphawk_api_key',
+        $api_key = $this->scopeConfig->getValue('shiphawk_order/options/shiphawk_api_key',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
-        $gateway_url = $this->scopeConfig->getValue('general/options/shiphawk_gateway_url',
+        $gateway_url = $this->scopeConfig->getValue('shiphawk_order/options/shiphawk_gateway_url',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         $params = http_build_query(['api_key' => $api_key]);

--- a/app/code/Shiphawk/Order/Observer/SendOrder.php
+++ b/app/code/Shiphawk/Order/Observer/SendOrder.php
@@ -32,7 +32,7 @@ class SendOrder implements ObserverInterface
 
     public function pushOrder($order) {
 
-        $active = $this->scopeConfig->getValue('general/options/shiphawk_active',
+        $active = $this->scopeConfig->getValue('shiphawk_order/options/shiphawk_active',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         if (!$active) {
@@ -127,9 +127,9 @@ class SendOrder implements ObserverInterface
 
     protected function _push($jsonOrderRequest) {
 
-        $api_key = $this->scopeConfig->getValue('general/options/shiphawk_api_key',
+        $api_key = $this->scopeConfig->getValue('shiphawk_order/options/shiphawk_api_key',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
-        $gateway_url = $this->scopeConfig->getValue('general/options/shiphawk_gateway_url',
+        $gateway_url = $this->scopeConfig->getValue('shiphawk_order/options/shiphawk_gateway_url',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         $params = http_build_query(['api_key' => $api_key]);

--- a/app/code/Shiphawk/Order/etc/adminhtml/system.xml
+++ b/app/code/Shiphawk/Order/etc/adminhtml/system.xml
@@ -10,9 +10,10 @@
         <tab id="shiphawk" sortOrder="10" translate="label">
             <label>ShipHawk</label>
         </tab>
-        <section id="general" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label">
+        <section id="shiphawk_order" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label">
             <label>ShipHawk Order Options</label>
             <tab>shiphawk</tab>
+            <resource>Shiphawk_Order::config</resource>
             <group id="options" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label">
                 <label>ShipHawk Order</label>
                 <field id="shiphawk_active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/app/code/Shiphawk/Order/etc/events.xml
+++ b/app/code/Shiphawk/Order/etc/events.xml
@@ -6,7 +6,7 @@
     <event name="sales_order_save_after">
         <observer name="shiphawk_sales_order_save_after" instance="Shiphawk\Order\Observer\ChangeStatus" />
     </event>
-    <event name="admin_system_config_changed_section_general">
-        <observer name="custom_admin_system_config_changed_section_general" instance="Shiphawk\Order\Observer\CheckConfiguration"/>
+    <event name="admin_system_config_changed_section_shiphawk_order">
+        <observer name="custom_admin_system_config_changed_section_shiphawk_order" instance="Shiphawk\Order\Observer\CheckConfiguration"/>
     </event>
 </config>


### PR DESCRIPTION
This is a solution for issue #1 . I have modified the config path for the ShipHawk Order section to be `shiphawk_order` and updated all references to these fields.

Doing so allows the General -> General section and fields to go back to their original place to avoid confusion for Magento users who install this module. 