### PR TITLE
[#17536] Do not receive rates if the destination zip code is empty

### DIFF
--- a/app/code/Shiphawk/Shipping/Model/Carrier.php
+++ b/app/code/Shiphawk/Shipping/Model/Carrier.php
@@ -96,6 +96,11 @@ class Carrier extends AbstractCarrier implements CarrierInterface
             return false;
         }
 
+        $destinationZip = $request->getDestPostcode();
+        if (!$destinationZip) {
+            return false;
+        }
+
         $result = $this->rateResultFactory->create();
 
         $items = $this->getItems($request);


### PR DESCRIPTION
Story: https://pm.shiphawk.com/issues/17536