### PR TITLE
[#19315] Allow ShipHawk to set a separate rate timeout for each ERP/e-commerce connector

### DIFF
--- a/app/code/Shiphawk/Shipping/Model/Carrier.php
+++ b/app/code/Shiphawk/Shipping/Model/Carrier.php
@@ -123,7 +123,8 @@ class Carrier extends AbstractCarrier implements CarrierInterface
                 'is_residential' => 'true'
             ),
             'apply_rules'=>'true',
-            'rate_source'=>'magento2'
+            'rate_source'=>'magento2',
+            'source_system'=>'magento2'
         );
 
         $rateResponse = $this->getRates($rateRequest);


### PR DESCRIPTION
**Story:**
https://pm.shiphawk.com/issues/19315

**Description:**
Add `source_system` to rate request