### PR TITLE
[DEV-29389] Add rates caching

### DIFF
--- a/app/code/Shiphawk/Shipping/Model/Carrier.php
+++ b/app/code/Shiphawk/Shipping/Model/Carrier.php
@@ -22,6 +22,9 @@ require_once __DIR__ . '/../../ShGatewayBuilder.php';
 
 class Carrier extends AbstractCarrier implements CarrierInterface
 {
+    const RATE_CACHE_TTL = 120; // 2 minutes
+    const CURL_TIMEOUT = 10; // seconds
+
     /**
      * Carrier's code
      *
@@ -186,12 +189,26 @@ class Carrier extends AbstractCarrier implements CarrierInterface
     public function getRates($rateRequest)
     {
         $jsonRateRequest = json_encode($rateRequest);
+        $cacheKey = 'shiphawk_rates_' . md5($jsonRateRequest);
+
+        $cached = $this->catalogSession->getData($cacheKey);
+        if ($cached && isset($cached['timestamp']) && (time() - $cached['timestamp']) < self::RATE_CACHE_TTL) {
+            $this->mlog("Cache hit for key: {$cacheKey}", 'shiphawk_rates_response.log');
+            return $cached['response'];
+        }
 
         try {
             $response = $this->_get($jsonRateRequest);
 
+            if ($response && !property_exists($response, 'error')) {
+                $this->catalogSession->setData($cacheKey, [
+                    'response' => $response,
+                    'timestamp' => time()
+                ]);
+            }
+
             return $response;
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->logger->critical($e);
         }
     }
@@ -206,20 +223,29 @@ class Carrier extends AbstractCarrier implements CarrierInterface
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
         curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonRateRequest);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, self::CURL_TIMEOUT);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($ch, CURLOPT_HTTPHEADER, array(
                 'Content-Type: application/json',
                 'Content-Length: ' . strlen($jsonRateRequest)
             )
         );
 
+        $startTime = microtime(true);
         $resp = curl_exec($ch);
-        $arr_res = json_decode($resp);
-
-        $this->mlog($resp, 'shiphawk_rates_response.log');
-
-        //$this->logger->debug(var_export($arr_res, true));
-
+        $elapsed = round(microtime(true) - $startTime, 2);
+        $curlError = curl_error($ch);
         curl_close($ch);
+
+        if ($curlError) {
+            $this->mlog("Request failed after {$elapsed}s | Error: {$curlError} | URL: {$chUrl}", 'shiphawk_rates_response.log');
+            $this->logger->error("ShipHawk rate request failed: {$curlError}");
+            return null;
+        }
+
+        $arr_res = json_decode($resp);
+        $this->mlog("Response time: {$elapsed}s | URL: {$chUrl} | Response: {$resp}", 'shiphawk_rates_response.log');
+
         return $arr_res;
     }
 


### PR DESCRIPTION
Description:

Summary

Add session-based caching for ShipHawk rate API responses (2 min TTL) to eliminate redundant API calls during checkout
Add 10-second cURL timeout to prevent requests from hanging indefinitely
Add response time logging and cURL error handling
Problem

During PayPal checkout, Magento calls collectRates() 3-5 times with identical parameters. Each call hits the ShipHawk API without caching. On accounts with slow rate responses (~35s), this causes the PayPal popup to hang and timeout, blocking checkout entirely.

Changes

Rate caching: Responses are cached in the catalog session keyed by MD5 of the request payload. Identical requests within 2 minutes return cached results instantly.
cURL timeout: Requests that exceed 10 seconds are aborted gracefully instead of hanging. This aligns with PayPal's popup timeout window (~10-15s).
Error handling: cURL failures (including timeouts) are logged and return null instead of crashing.
Test results

Before: 5 API calls per checkout
After: 3 API calls + 2 cache hits, nothing over 5s

